### PR TITLE
disable firebase on web

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -6,7 +6,7 @@ import DomWebViewHost from "@/src/components/blocks/DomWebViewHost";
 import FireBase from "@/src/components/blocks/Firebase";
 
 import { StatusBar } from "expo-status-bar";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function Page() {
@@ -14,9 +14,7 @@ export default function Page() {
 
   return (
     <View style={{ flex: 1, backgroundColor: "#fff" }}>
-      <AuthGuard>
-        <FireBase />
-      </AuthGuard>
+      <AuthGuard>{Platform.OS !== "web" && <FireBase />}</AuthGuard>
       <View style={{ height: insets.top, backgroundColor: "#fff" }} />
       <StatusBar style="dark" />
       <View style={{ flex: 1, width: "100%", display: "block" }}>


### PR DESCRIPTION
Disable the native firebase integration for web testing, as it causes the app to crash.

Closes #45 